### PR TITLE
Missing scope declaration

### DIFF
--- a/si4735_2.8_TFT/si4735_2.8_TFT.ino
+++ b/si4735_2.8_TFT/si4735_2.8_TFT.ino
@@ -713,6 +713,22 @@ TFT_eSPI tft = TFT_eSPI();
 
 SI4735 si4735;
 
+void IRAM_ATTR RotaryEncFreq()
+{
+  uint8_t encoderStatus = encoder.process();
+  if (encoderStatus)
+  {
+    if (encoderStatus == DIR_CW)
+    {
+      encoderCount = 1;
+    }
+    else
+    {
+      encoderCount = -1;
+    }
+  }
+}
+
 //=======================================================================================
 void IRAM_ATTR RotaryEncFreq()
 //=======================================================================================


### PR DESCRIPTION
Solved following error. Missing declaration

error: 'RotaryEncFreq' was not declared in this scope